### PR TITLE
Fix proxy data type and up version

### DIFF
--- a/marqeta/__init__.py
+++ b/marqeta/__init__.py
@@ -298,7 +298,7 @@ class Client(object):
                     timeout=self.timeout,
                     verify=ca_file.name,
                     params=query_params,
-                    proxies=proxy_data["https"],
+                    proxies={"https": proxy_data["https"]},
                     data=json.dumps(data),
                 )
                 return response

--- a/marqeta/version.py
+++ b/marqeta/version.py
@@ -1,2 +1,2 @@
 # Make sure to update version number in setup.py as well when creating a new tag
-__version__ = "0.2.4"
+__version__ = "0.2.5"

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     name="marqeta",
     # Manually adding version number due to issues with poetry when calling __version__
     # This has to be updated alongside version.py when the version changes
-    version="0.2.4",
+    version="0.2.5",
     description="Marqeta Python SDK",
     author="Marqeta, Inc.",
     url="https://github.com/marqeta/marqeta-python",


### PR DESCRIPTION
Proxies parameter for requests library expects a dictionary for the proxy "https" info and we were passing a string instead.